### PR TITLE
cbortojson: replace FILE with MEMFILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ ifneq ($(BUILD_SHARED),1)
 endif
 endif
 
-INSTALL_TARGETS += $(bindir)/cbordump
 ifeq ($(BUILD_SHARED),1)
 BINLIBRARY=lib/libtinycbor.so
 INSTALL_TARGETS += $(libdir)/libtinycbor.so.$(VERSION)
@@ -95,31 +94,9 @@ TINYCBOR_SOURCES = \
 	src/cbortojson.c \
 	src/cborvalidation.c \
 #
-# if open_memstream is unavailable on the system, try to implement our own
-# version using funopen or fopencookie
-ifeq ($(open_memstream-pass),)
-  ifeq ($(funopen-pass)$(fopencookie-pass),)
-    CFLAGS += -DWITHOUT_OPEN_MEMSTREAM
-    ifeq ($(wildcard .config),.config)
-        $(warning warning: funopen and fopencookie unavailable, open_memstream can not be implemented and conversion to JSON will not work properly!)
-    endif
-  else
-    TINYCBOR_SOURCES += src/open_memstream.c
-  endif
-endif
+CFLAGS += -DWITHOUT_OPEN_MEMSTREAM
 endif
 
-# json2cbor depends on an external library (cjson)
-ifneq ($(cjson-pass)$(system-cjson-pass),)
-  JSON2CBOR_SOURCES = tools/json2cbor/json2cbor.c
-  INSTALL_TARGETS += $(bindir)/json2cbor
-  ifeq ($(system-cjson-pass),1)
-    LDFLAGS_CJSON = -lcjson
-  else
-    JSON2CBOR_SOURCES += src/cjson/cJSON.c
-    json2cbor_CCFLAGS = -I$(SRCDIR)src/cjson
-  endif
-endif
 
 # Rules
 all: .config \

--- a/src/cborjson.h
+++ b/src/cborjson.h
@@ -56,11 +56,7 @@ typedef struct {
 #define MEMFILE_INIT(buf, buf_len) { .buffer = (buf), .buffer_len = (buf_len), .pos = 0 }
 
 CBOR_API CborError cbor_value_to_json_advance(MEMFILE *out, CborValue *value, int flags);
-CBOR_INLINE_API CborError cbor_value_to_json(MEMFILE *out, const CborValue *value, int flags)
-{
-    CborValue copy = *value;
-    return cbor_value_to_json_advance(out, &copy, flags);
-}
+CBOR_API CborError cbor_value_to_json(MEMFILE *out, const CborValue *value, int flags);
 
 #ifdef __cplusplus
 }

--- a/src/cborjson.h
+++ b/src/cborjson.h
@@ -47,8 +47,16 @@ enum CborToJsonFlags
     CborConvertDefaultFlags = 0
 };
 
-CBOR_API CborError cbor_value_to_json_advance(FILE *out, CborValue *value, int flags);
-CBOR_INLINE_API CborError cbor_value_to_json(FILE *out, const CborValue *value, int flags)
+typedef struct {
+    char *const buffer;
+    const size_t buffer_len;
+    size_t pos;
+} MEMFILE;
+
+#define MEMFILE_INIT(buf, buf_len) { .buffer = (buf), .buffer_len = (buf_len), .pos = 0 }
+
+CBOR_API CborError cbor_value_to_json_advance(MEMFILE *out, CborValue *value, int flags);
+CBOR_INLINE_API CborError cbor_value_to_json(MEMFILE *out, const CborValue *value, int flags)
 {
     CborValue copy = *value;
     return cbor_value_to_json_advance(out, &copy, flags);

--- a/src/cbortojson.c
+++ b/src/cbortojson.c
@@ -731,4 +731,17 @@ CborError cbor_value_to_json_advance(MEMFILE *out, CborValue *value, int flags)
     return value_to_json(out, value, flags, cbor_value_get_type(value), &status);
 }
 
+CborError cbor_value_to_json(MEMFILE *out, const CborValue *value, int flags)
+{
+    CborValue copy = *value;
+    int retv = cbor_value_to_json_advance(out, &copy, flags);
+    if (retv) {
+        return retv;
+    }
+    if(fputc('\0', out) < 0) {
+        return CborErrorIO;
+    }
+    return retv;
+}
+
 /** @} */


### PR DESCRIPTION
we want to dump json to buffers rather than to FILEs. Unfortunately fmemopen is not available on windows platform so we have to come up with our own solution.


EDIT: this is a fake PR for reviewing purposes. I am not planning to merge this branch into master, I think it would be clearer to leave these changes in its own branch named ``v0.6.0-memfile`` 